### PR TITLE
Updated sizing rules for better responsiveness with wide screen resolutions

### DIFF
--- a/cinematoggle.css
+++ b/cinematoggle.css
@@ -76,6 +76,7 @@ body.cinemachat #videowrap .embed-responsive {
     height: 100% !important;
     width: 100% !important;
     bottom: 0 !important;
+    padding: 1% !important;
 }
 
 body.cinemachat:not(.synchtube) #videowrap .embed-responsive { right: 0 !important; }
@@ -83,12 +84,12 @@ body.cinemachat.synchtube #videowrap .embed-responsive { left: 0 !important; }
 
 body.cinemachat #videowrap {
     position: fixed !important;
-    top: 0 !important;
-    padding: 0 !important;
-    z-index: 3000 !important;
-    background-color: black;
-    height: 100% !important;
-    width: calc(100% - 400px) !important;
+  	top: 0 !important;
+  	padding: 0 !important;
+  	z-index: 3000 !important;
+  	background-color: black;
+  	height: 100% !important;
+  	width: 80% !important;
 }
 
 body.cinemachat:not(.synchtube) #videowrap { right: 0 !important; }

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -131,9 +131,7 @@ function toggleChat() {
         // Added by Quigly
         // Adds HTML span element to the cheat header so emotes can be toggled while in cinemamode.
         updateEmoteBtnLocation(){
-          var compactEmoteBtn = $('<span id="emotelistbtn" style="visibility: hidden;" class="label pull-right pointer inlineemote">Emotes</span><span class="glyphicon glyphicon-picture"></span>');
-
-          compactEmoteBtn.appendTo("#chatheader");
+         $('<span id="emotelistbtn" style="visibility: hidden;" class="label pull-right pointer inlineemote">Emotes</span><span class="glyphicon glyphicon-picture"></span>').appendTo("#chatheader");
         },
         loadStyle: function() {
             $.ajax(this.host).done((data=>{

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -145,7 +145,7 @@ function toggleChat() {
                 this.createButtons();
                 this.createStyle(data);
                 this.registerCommand();
-                updateEmoteBtnLocation();
+                this.updateEmoteBtnLocation();
                 if (localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`) !== null) {
                     if (parseInt(localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`))) {
                         $("body").addClass("cinema-nopoll")

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -139,14 +139,15 @@ function toggleChat() {
           ebtn.text("Emotes");
           ebtn.attr("onclick", "EMOTELISTMODAL.modal()");
 
-          var gicon = $('<span>').addClass("glyphicon glyphicon-picture").appendTo("#emotelistbtn");
+          var gicon = $('<span>').addClass("glyphicon glyphicon-picture");
+          gicon.appentTo("#emotelistbtn")
         },
         loadStyle: function() {
             $.ajax(this.host).done((data=>{
                 this.createButtons();
                 this.createStyle(data);
                 this.registerCommand();
-                this.updateEmoteBtnLocation().appendTo("#chatheader");
+                this.updateEmoteBtnLocation();
                 if (localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`) !== null) {
                     if (parseInt(localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`))) {
                         $("body").addClass("cinema-nopoll")

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -130,8 +130,8 @@ function toggleChat() {
         },
         // Added by Quigly
         // Adds HTML span element to the cheat header so emotes can be toggled while in cinemamode.
-        updateEmoteBtnLocation(){
-         $('<span id="emotelistbtn" style="visibility: hidden;" class="label pull-right pointer inlineemote">Emotes</span><span class="glyphicon glyphicon-picture"></span>').appendTo("#chatheader");
+        updateEmoteBtnLocation()  {
+          $('<span id="emotelistbtn" style="visibility: hidden;" class="label pull-right pointer inlineemote">Emotes <span class="glyphicon glyphicon-picture"></span></span>').appendTo("#chatheader");
         },
         loadStyle: function() {
             $.ajax(this.host).done((data=>{

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -131,10 +131,8 @@ function toggleChat() {
         // Added by Quigly
         // Adds HTML span element to the cheat header so emotes can be toggled while in cinemamode.
         updateEmoteBtnLocation(){
-          var compactEmoteBtn = $('<span id="emotelistbtn" style="visibility: hidden;" class="label pull-right pointer inlineemote">Emotes</span>');
+          var compactEmoteBtn = $('<span id="emotelistbtn" style="visibility: hidden;" class="label pull-right pointer inlineemote">Emotes</span><span class="glyphicon glyphicon-picture"></span>');
 
-          var gicon = $('<span class="glyphicon glyphicon-picture"></span>').appendTo("#emotelistbtn");
-          
           compactEmoteBtn.appendTo("#chatheader");
         },
         loadStyle: function() {

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -80,7 +80,7 @@ function toggleChat() {
       // Updated to using GitHack for faster delivery.
         // host: "https://gitcdn.link/cdn/intentionallyIncomplete/quiglys_movie_repo/259f469d860d912862f51efb077ef8e065666a5f/cinematoggle.css",
 
-        host: "https://raw.githack.com/intentionallyIncomplete/quiglys_movie_repo/master/cinematoggle.css",
+        host: "https://raw.githack.com/intentionallyIncomplete/quiglys_movie_repo/alpha_changes/cinematoggle.css",
         initialize: function() {
             if (CLIENT.cinemaMode) {
                 return

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -131,18 +131,11 @@ function toggleChat() {
         // Added by Quigly
         // Adds HTML span element to the cheat header so emotes can be toggled while in cinemamode.
         updateEmoteBtnLocation(){
+          var compactEmoteBtn = $('<span id="emotelistbtn" style="visibility: hidden;" class="label pull-right pointer inlineemote">Emotes</span>');
 
-          var ebtn = $('<span>');
-          ebtn.attr("id", "emotelistbtn");
-          ebtn.attr("style", "visibility: hidden;");
-          ebtn.addClass("label pull-right pointer inlineemote");
-          ebtn.text("Emotes");
-          ebtn.attr("onclick", "EMOTELISTMODAL.modal()");
-
-          var gicon = $('<span>');
-          gicon.addClass("glyphicon glyphicon-picture");
-          gicon.appendTo("#emotelistbtn");
-          ebtn.appendTo("#chatheader");
+          var gicon = $('<span class="glyphicon glyphicon-picture"></span>').appendTo("#emotelistbtn");
+          
+          compactEmoteBtn.appendTo("#chatheader");
         },
         loadStyle: function() {
             $.ajax(this.host).done((data=>{

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -136,7 +136,7 @@ function toggleChat() {
 
           var ebtn = $('<span>').attr("id", "emotelistbtn").attr("style", "visibility: hidden;").addClass("label pull-right pointer inlineemote").text("Emotes").attr("onclick", "EMOTELISTMODAL.modal()");
 
-          var gicon = $('<span>').addClass("glyphicon glyphicon-picture").appendTo("#emotelistbtn");
+          var gicon = $('<span>').addClass("glyphicon glyphicon-picture").appendTo(".inlineemote");
 
           var allTogetherNow = ebtn.appendTo("#chatheader");
         },

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -140,7 +140,8 @@ function toggleChat() {
           ebtn.attr("onclick", "EMOTELISTMODAL.modal()");
 
           var gicon = $('<span>').addClass("glyphicon glyphicon-picture");
-          gicon.appentTo("#emotelistbtn")
+          gicon.appendTo("#emotelistbtn");
+          ebtn.appendTo("#chatheader");
         },
         loadStyle: function() {
             $.ajax(this.host).done((data=>{

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -77,7 +77,10 @@ function toggleChat() {
         $('a[onclick*="chatOnly"]').parent().after($("<li>").append($("<a>").attr("href", "javascript:void(0)").attr("onclick", "javascript:toggleChat()").text("Remove Chat")))
     }
     ({
-        host: "https://gitcdn.link/cdn/intentionallyIncomplete/quiglys_movie_repo/259f469d860d912862f51efb077ef8e065666a5f/cinematoggle.css",
+      // Updated to using GitHack for faster delivery.
+        // host: "https://gitcdn.link/cdn/intentionallyIncomplete/quiglys_movie_repo/259f469d860d912862f51efb077ef8e065666a5f/cinematoggle.css",
+
+        host: "https://raw.githack.com/intentionallyIncomplete/quiglys_movie_repo/master/cinematoggle.css",
         initialize: function() {
             if (CLIENT.cinemaMode) {
                 return
@@ -105,7 +108,6 @@ function toggleChat() {
         },
         createStyle: function(body) {
             this.style = $("<style>").attr("type", "text/css").attr("id", "cinemaStyle").html(body).appendTo("head");
-            $('<span class="label pull-right pointer inlineemote" id="emotelistbtn" onclick="EMOTELISTMODAL.modal();" style="visibility: hidden;">Emotes	<span class="glyphicon glyphicon-picture"></span></span>').appendTo("#chatheader");
         },
         handleCommand(message, target) {
             var params = message.substring(1).replace(/cinema ?/, "").trim();
@@ -126,11 +128,24 @@ function toggleChat() {
         registerCommand() {
             $("#chatline").trigger("registerCommand", ["cinema", this.handleCommand.bind(this)])
         },
+        // Added by Quigly
+        // Adds HTML span element to the cheat header so emotes can be toggled while in
+        // cinemamode.
+        updateEmoteBtnLocation(){
+          // $('<span class="label pull-right pointer inlineemote" id="emotelistbtn" onclick="EMOTELISTMODAL.modal();" style="visibility: hidden;">Emotes	<span class="glyphicon glyphicon-picture"></span></span>').appendTo("#chatheader");
+
+          var ebtn = $('<span>').attr("id", "emotelistbtn").attr("style", "visibility: hidden;").addClass("label pull-right pointer inlineemote").text("Emotes").attr("onclick", "EMOTELISTMODAL.modal()");
+
+          var gicon = $('<span>').addClass("glyphicon glyphicon-picture").appendTo("#emotelistbtn");
+
+          var allTogetherNow = ebtn.appendTo("#chatheader");
+        },
         loadStyle: function() {
             $.ajax(this.host).done((data=>{
                 this.createButtons();
                 this.createStyle(data);
                 this.registerCommand();
+                updateEmoteBtnLocation();
                 if (localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`) !== null) {
                     if (parseInt(localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`))) {
                         $("body").addClass("cinema-nopoll")

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -129,23 +129,24 @@ function toggleChat() {
             $("#chatline").trigger("registerCommand", ["cinema", this.handleCommand.bind(this)])
         },
         // Added by Quigly
-        // Adds HTML span element to the cheat header so emotes can be toggled while in
-        // cinemamode.
+        // Adds HTML span element to the cheat header so emotes can be toggled while in cinemamode.
         updateEmoteBtnLocation(){
-          // $('<span class="label pull-right pointer inlineemote" id="emotelistbtn" onclick="EMOTELISTMODAL.modal();" style="visibility: hidden;">Emotes	<span class="glyphicon glyphicon-picture"></span></span>').appendTo("#chatheader");
 
-          var ebtn = $('<span>').attr("id", "emotelistbtn").attr("style", "visibility: hidden;").addClass("label pull-right pointer inlineemote").text("Emotes").attr("onclick", "EMOTELISTMODAL.modal()");
+          var ebtn = $('<span>');
+          ebtn.attr("id", "emotelistbtn");
+          ebtn.attr("style", "visibility: hidden;");
+          ebtn.addClass("label pull-right pointer inlineemote");
+          ebtn.text("Emotes");
+          ebtn.attr("onclick", "EMOTELISTMODAL.modal()");
 
-          var gicon = $('<span>').addClass("glyphicon glyphicon-picture").appendTo(".inlineemote");
-
-          var allTogetherNow = ebtn.appendTo("#chatheader");
+          var gicon = $('<span>').addClass("glyphicon glyphicon-picture").appendTo("#emotelistbtn");
         },
         loadStyle: function() {
             $.ajax(this.host).done((data=>{
                 this.createButtons();
                 this.createStyle(data);
                 this.registerCommand();
-                this.updateEmoteBtnLocation();
+                this.updateEmoteBtnLocation().appendTo("#chatheader");
                 if (localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`) !== null) {
                     if (parseInt(localStorage.getItem(`${CHANNEL.name}_cinemaHidePolls`))) {
                         $("body").addClass("cinema-nopoll")

--- a/cinematoggle_action.js
+++ b/cinematoggle_action.js
@@ -139,7 +139,8 @@ function toggleChat() {
           ebtn.text("Emotes");
           ebtn.attr("onclick", "EMOTELISTMODAL.modal()");
 
-          var gicon = $('<span>').addClass("glyphicon glyphicon-picture");
+          var gicon = $('<span>');
+          gicon.addClass("glyphicon glyphicon-picture");
           gicon.appendTo("#emotelistbtn");
           ebtn.appendTo("#chatheader");
         },


### PR DESCRIPTION
Some wide screen resolutions did not display the entire video for some reason. Changed the size of the chat box to 20% from 400px and videowrap is now 80% of page width compared to previous `calc(100% - 400px)` which adjusted for the static chat box size. 

Hopefully this solves future resolution issues beyond widescreen and issue #1 